### PR TITLE
The default packages were not reasonable.

### DIFF
--- a/containment/config.py
+++ b/containment/config.py
@@ -39,7 +39,7 @@ class _PersonalConfig(Object):
     projects: Path = path / "projects"
     os_packages: Path = path / "os_packages.json"
     lang_packages: Path = path / "lang_packages.json"
-    package_list: List[str] = ["vim", "tmux", "git", _SHELL.name]
+    package_list: List[str] = ["docker", _SHELL.name]
 
 
 @singleton


### PR DESCRIPTION
Issues:
Fixes #71

Problem: vim and tmux are idiosyncratic personal preferences.

Analysis: The default list should only include packages that are generally
required for the proper function of containment.

Tests: Naw.